### PR TITLE
SheepRL examples

### DIFF
--- a/.github/workflows/reusable_unit_tests.yaml
+++ b/.github/workflows/reusable_unit_tests.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-          extra: ['basic', 'stable-baselines', 'stable-baselines3', 'ray-rllib']
+          extra: ['basic', 'stable-baselines', 'stable-baselines3', 'ray-rllib', 'sheeprl']
           python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
@@ -63,6 +63,8 @@ jobs:
             echo "test_script=test_sb3.py" >> "$GITHUB_ENV"
           elif [ "${{ matrix.extra }}" == "ray-rllib" ]; then
             echo "test_script=test_ray_rllib.py" >> "$GITHUB_ENV"
+          elif [ "${{ matrix.extra }}" == "sheeprl" ]; then
+            echo "test_script=test_sheeprl.py" >> "$GITHUB_ENV"
           fi
 
       - name: Install proper packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache*
+sheeprl/logs

--- a/sheeprl/.env
+++ b/sheeprl/.env
@@ -1,0 +1,1 @@
+SHEEPRL_SEARCH_PATH=file://configs;pkg://sheeprl.configs

--- a/sheeprl/__main__.py
+++ b/sheeprl/__main__.py
@@ -1,0 +1,4 @@
+from train import train
+
+if __name__ == "__main__":
+    train()

--- a/sheeprl/configs/algo/custom_ppo_agent.yaml
+++ b/sheeprl/configs/algo/custom_ppo_agent.yaml
@@ -7,7 +7,8 @@ defaults:
   - _self_
 
 # Override default ppo arguments
-# `name` is a mandatory attribute, it must be equal to the algorithm name
+# `name` is a mandatory attribute, it must be equal to the filename 
+# of the file in which the algorithm is defined.
 # If you inherit the default configurations of a specific algoritm,
 # then you do not need to define it, since it is already defined in the default configs
 name: ppo

--- a/sheeprl/configs/algo/custom_ppo_agent.yaml
+++ b/sheeprl/configs/algo/custom_ppo_agent.yaml
@@ -1,0 +1,48 @@
+defaults:
+  # Take default configurations of PPO
+  - ppo
+  # define Adam optimizer under the `optimizer` key 
+  # from the sheeprl/configs/optim folder
+  - override /optim@optimizer: adam
+  - _self_
+
+# Override default ppo arguments
+# `name` is a mandatory attribute, it must be equal to the algorithm name
+# If you inherit the default configurations of a specific algoritm,
+# then you do not need to define it, since it is already defined in the default configs
+name: ppo
+update_epochs: 1
+normalize_advantages: True
+rollout_steps: 32
+dense_units: 16
+mlp_layers: 1
+dense_act: torch.nn.Tanh
+max_grad_norm: 1.0
+
+# Encoder
+encoder:
+  cnn_features_dim: 128
+  mlp_features_dim: 32
+  dense_units: ${algo.dense_units}
+  mlp_layers: ${algo.mlp_layers}
+  dense_act: ${algo.dense_act}
+  layer_norm: ${algo.layer_norm}
+
+# Actor
+actor:
+  dense_units: ${algo.dense_units}
+  mlp_layers: ${algo.mlp_layers}
+  dense_act: ${algo.dense_act}
+  layer_norm: ${algo.layer_norm}
+
+# Critic
+critic:
+  dense_units: ${algo.dense_units}
+  mlp_layers: ${algo.mlp_layers}
+  dense_act: ${algo.dense_act}
+  layer_norm: ${algo.layer_norm}
+
+# Single optimizer for both actor and critic
+optimizer:
+  lr: 5e-3
+  eps: 1e-6

--- a/sheeprl/configs/env/custom_env.yaml
+++ b/sheeprl/configs/env/custom_env.yaml
@@ -1,0 +1,50 @@
+defaults:
+  - default
+  - _self_
+
+# Override from `default` config
+# `default` config contains the arguments shared
+# among all the environments in SheepRL
+id: doapp
+frame_stack: 1
+sync_env: True
+action_repeat: 1
+num_envs: 1
+screen_size: 64
+grayscale: False
+clip_rewards: False
+capture_video: True
+frame_stack_dilation: 1
+max_episode_steps: null
+reward_as_observation: False
+
+# DOAPP-related arguments
+wrapper:
+  # class to be instantiated
+  _target_: sheeprl.envs.diambra.DiambraWrapper
+  id: ${env.id}
+  action_space: diambra.arena.SpaceTypes.DISCRETE 
+    # or `diambra.arena.SpaceTypes.MULTI_DISCRETE`
+  screen_size: ${env.screen_size}
+  grayscale: ${env.grayscale}
+  repeat_action: ${env.action_repeat}
+  rank: null
+  log_level: 0
+  increase_performance: True
+  diambra_settings:
+    role: diambra.arena.Roles.P1 # or `diambra.arena.Roles.P1` or `null`
+    step_ratio: 6
+    difficulty: 4
+    continue_game: 0.0
+    show_final: False
+    outfits: 2
+    splash_screen: False
+  diambra_wrappers:
+    stack_actions: 1
+    no_op_max: 0
+    no_attack_buttons_combinations: False
+    add_last_action: True
+    scale: False
+    exclude_image_scaling: False
+    process_discrete_binary: False
+    role_relative: True

--- a/sheeprl/configs/env/custom_parallel_env.yaml
+++ b/sheeprl/configs/env/custom_parallel_env.yaml
@@ -1,0 +1,50 @@
+defaults:
+  - default
+  - _self_
+
+# Override from `default` config
+# `default` config contains the arguments shared
+# among all the environments in SheepRL
+id: doapp
+frame_stack: 1
+sync_env: False
+action_repeat: 1
+num_envs: 4
+screen_size: 64
+grayscale: False
+clip_rewards: False
+capture_video: True
+frame_stack_dilation: 1
+max_episode_steps: null
+reward_as_observation: False
+
+# DOAPP-related arguments
+wrapper:
+  # class to be instantiated
+  _target_: sheeprl.envs.diambra.DiambraWrapper
+  id: ${env.id}
+  action_space: diambra.arena.SpaceTypes.DISCRETE 
+    # or `diambra.arena.SpaceTypes.MULTI_DISCRETE`
+  screen_size: ${env.screen_size}
+  grayscale: ${env.grayscale}
+  repeat_action: ${env.action_repeat}
+  rank: null
+  log_level: 0
+  increase_performance: True
+  diambra_settings:
+    role: diambra.arena.Roles.P1 # or `diambra.arena.Roles.P1` or `null`
+    step_ratio: 6
+    difficulty: 4
+    continue_game: 0.0
+    show_final: False
+    outfits: 2
+    splash_screen: False
+  diambra_wrappers:
+    stack_actions: 1
+    no_op_max: 0
+    no_attack_buttons_combinations: False
+    add_last_action: True
+    scale: False
+    exclude_image_scaling: False
+    process_discrete_binary: False
+    role_relative: True

--- a/sheeprl/configs/env/custom_parallel_env.yaml
+++ b/sheeprl/configs/env/custom_parallel_env.yaml
@@ -1,50 +1,8 @@
 defaults:
-  - default
+  # Inherit evironment configurations from custom_env.yaml
+  - custom_env
   - _self_
 
-# Override from `default` config
-# `default` config contains the arguments shared
-# among all the environments in SheepRL
-id: doapp
-frame_stack: 1
-sync_env: False
-action_repeat: 1
+# Override parameters
+sync_env: False # True if you want to use the gymnasium.vector.SyncVectorEnv
 num_envs: 4
-screen_size: 64
-grayscale: False
-clip_rewards: False
-capture_video: True
-frame_stack_dilation: 1
-max_episode_steps: null
-reward_as_observation: False
-
-# DOAPP-related arguments
-wrapper:
-  # class to be instantiated
-  _target_: sheeprl.envs.diambra.DiambraWrapper
-  id: ${env.id}
-  action_space: diambra.arena.SpaceTypes.DISCRETE 
-    # or `diambra.arena.SpaceTypes.MULTI_DISCRETE`
-  screen_size: ${env.screen_size}
-  grayscale: ${env.grayscale}
-  repeat_action: ${env.action_repeat}
-  rank: null
-  log_level: 0
-  increase_performance: True
-  diambra_settings:
-    role: diambra.arena.Roles.P1 # or `diambra.arena.Roles.P1` or `null`
-    step_ratio: 6
-    difficulty: 4
-    continue_game: 0.0
-    show_final: False
-    outfits: 2
-    splash_screen: False
-  diambra_wrappers:
-    stack_actions: 1
-    no_op_max: 0
-    no_attack_buttons_combinations: False
-    add_last_action: True
-    scale: False
-    exclude_image_scaling: False
-    process_discrete_binary: False
-    role_relative: True

--- a/sheeprl/configs/exp/custom_exp.yaml
+++ b/sheeprl/configs/exp/custom_exp.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+
+defaults:
+  # Selects the algorithm and the environment
+  - override /algo: custom_ppo_agent
+  - override /env: custom_env
+  - _self_
+
+# Experiment
+total_steps: 1024
+per_rank_batch_size: 16
+
+# Buffer
+buffer:
+  share_data: False
+  size: ${algo.rollout_steps}
+
+checkpoint:
+  save_last: True
+
+cnn_keys:
+  encoder: [frame]
+mlp_keys:
+  encoder:
+    - own_character
+    - own_health
+    - own_side
+    - own_wins
+    - opp_character
+    - opp_health
+    - opp_side
+    - opp_wins
+    - stage
+    - timer
+    - action

--- a/sheeprl/configs/exp/custom_fabric_exp.yaml
+++ b/sheeprl/configs/exp/custom_fabric_exp.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+
+defaults:
+  # Inherit configs from custom_exp
+  - custom_exp
+  - _self_
+
+# Set Fabric parameters
+fabric:
+  devices: 2
+  accelerator: cuda
+  precision: bf16

--- a/sheeprl/configs/exp/custom_metric_exp.yaml
+++ b/sheeprl/configs/exp/custom_metric_exp.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+
+defaults:
+  # Inherit configs from custom_fabric_exp
+  - custom_fabric_exp
+  - _self_
+
+# Set Metric parameters
+metric:
+  disable_timer: True
+  sync_on_compute: True
+  aggregator:
+    metrics:
+      Loss/value_loss:
+        _target_: torchmetrics.MeanMetric
+        sync_on_compute: ${metric.sync_on_compute}
+      Loss/policy_loss:
+        _target_: torchmetrics.MeanMetric
+        sync_on_compute: ${metric.sync_on_compute}
+      Loss/entropy_loss:
+        _target_: torchmetrics.MeanMetric
+        sync_on_compute: ${metric.sync_on_compute}

--- a/sheeprl/configs/exp/custom_parallel_env_exp.yaml
+++ b/sheeprl/configs/exp/custom_parallel_env_exp.yaml
@@ -1,35 +1,8 @@
 # @package _global_
 
 defaults:
-  # Selects the algorithm and the environment
-  - override /algo: custom_ppo_agent
+  # Inherit configs from custom_exp
+  - custom_exp
+  # Override the environment configurations
   - override /env: custom_parallel_env
   - _self_
-
-# Experiment
-total_steps: 1024
-per_rank_batch_size: 16
-
-# Buffer
-buffer:
-  share_data: False
-  size: ${algo.rollout_steps}
-
-checkpoint:
-  save_last: True
-
-cnn_keys:
-  encoder: [frame]
-mlp_keys:
-  encoder:
-    - own_character
-    - own_health
-    - own_side
-    - own_wins
-    - opp_character
-    - opp_health
-    - opp_side
-    - opp_wins
-    - stage
-    - timer
-    - action

--- a/sheeprl/configs/exp/custom_parallel_env_exp.yaml
+++ b/sheeprl/configs/exp/custom_parallel_env_exp.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+
+defaults:
+  # Selects the algorithm and the environment
+  - override /algo: custom_ppo_agent
+  - override /env: custom_parallel_env
+  - _self_
+
+# Experiment
+total_steps: 1024
+per_rank_batch_size: 16
+
+# Buffer
+buffer:
+  share_data: False
+  size: ${algo.rollout_steps}
+
+checkpoint:
+  save_last: True
+
+cnn_keys:
+  encoder: [frame]
+mlp_keys:
+  encoder:
+    - own_character
+    - own_health
+    - own_side
+    - own_wins
+    - opp_character
+    - opp_health
+    - opp_side
+    - opp_wins
+    - stage
+    - timer
+    - action

--- a/sheeprl/evaluate.py
+++ b/sheeprl/evaluate.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 from sheeprl.cli import evaluation
 
 
-@hydra.main(version_base="1.13", config_path=CONFIGS_PATH, config_name="eval_config")
+@hydra.main(version_base="1.3", config_path=CONFIGS_PATH, config_name="eval_config")
 def run(cfg: DictConfig):
     evaluation(cfg)
 

--- a/sheeprl/evaluate.py
+++ b/sheeprl/evaluate.py
@@ -1,0 +1,16 @@
+# Diambra Agents
+
+import hydra
+from diambra.arena.sheeprl import CONFIGS_PATH
+from omegaconf import DictConfig
+
+from sheeprl.cli import evaluation
+
+
+@hydra.main(version_base="1.13", config_path=CONFIGS_PATH, config_name="eval_config")
+def run(cfg: DictConfig):
+    evaluation(cfg)
+
+
+if __name__ == "__main__":
+    run()

--- a/sheeprl/train.py
+++ b/sheeprl/train.py
@@ -16,7 +16,7 @@ def check_configs(cfg: DictConfig):
         )
 
 
-@hydra.main(version_base="1.13", config_path=CONFIGS_PATH, config_name="config")
+@hydra.main(version_base="1.3", config_path=CONFIGS_PATH, config_name="config")
 def train(cfg: DictConfig):
     check_configs(cfg)
     run(cfg)

--- a/sheeprl/train.py
+++ b/sheeprl/train.py
@@ -8,7 +8,6 @@ from sheeprl.cli import run
 
 
 def check_configs(cfg: DictConfig):
-    print(cfg.env)
     if "diambra" not in cfg.env.wrapper._target_:
         raise ValueError(
             f"You must choose a DIAMBRA environment. "

--- a/sheeprl/train.py
+++ b/sheeprl/train.py
@@ -1,0 +1,26 @@
+# Diambra Agents
+
+import hydra
+from diambra.arena.sheeprl import CONFIGS_PATH
+from omegaconf import DictConfig
+
+from sheeprl.cli import run
+
+
+def check_configs(cfg: DictConfig):
+    print(cfg.env)
+    if "diambra" not in cfg.env.wrapper._target_:
+        raise ValueError(
+            f"You must choose a DIAMBRA environment. "
+            f"Got '{cfg.env.id}' provided by '{cfg.env.wrapper._target_.split('.')[-2]}'."
+        )
+
+
+@hydra.main(version_base="1.13", config_path=CONFIGS_PATH, config_name="config")
+def train(cfg: DictConfig):
+    check_configs(cfg)
+    run(cfg)
+
+
+if __name__ == "__main__":
+    train()

--- a/tests/test_sheeprl.py
+++ b/tests/test_sheeprl.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import sys
+import warnings
+from unittest import mock
+
+import pytest
+from diambra.arena.utils.engine_mock import load_mocker
+
+# Add the scripts directory to sys.path
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "sheeprl"))
+sys.path.append(ROOT_DIR)
+
+import evaluate
+import train
+
+STANDARD_ARGS = [
+    os.path.join(ROOT_DIR, "__main__.py"),
+    "env.capture_video=False",
+    "metric.log_level=0",
+    "checkpoint.every=10000000",
+    "buffer.memmap=False",
+]
+
+
+def func(mocker, n_envs, args, evaluation=False, root_dir=None, run_name=None):
+    load_mocker(mocker)
+
+    try:
+        # Environment setup
+        initial_port = 32781
+        envs = f"127.0.0.1:{initial_port}"
+        for i in range(1, n_envs):
+            envs += f" 127.0.0.1:{initial_port + i}"
+        os.environ["DIAMBRA_ENVS"] = envs
+
+        # SheepRL config folder setup
+        os.environ[
+            "SHEEPRL_SEARCH_PATH"
+        ] = "file://sheeprl/configs;pkg://sheeprl.configs"
+
+        # Execution of the train script
+        with mock.patch.object(sys, "argv", STANDARD_ARGS + args):
+            train.train()
+
+        if evaluation:
+            # Take checkpoint
+            ckpt_root = os.path.join("logs", "runs", root_dir, run_name)
+            ckpt_dir = sorted([d for d in os.listdir(ckpt_root) if "version" in d])[-1]
+            ckpt_path = os.path.join(ckpt_root, ckpt_dir, "checkpoint")
+            ckpt_file_name = os.listdir(ckpt_path)[-1]
+            ckpt_path = os.path.join(ckpt_path, ckpt_file_name)
+            # Execution of the evaluate script
+            with mock.patch.object(
+                sys, "argv", STANDARD_ARGS[:1] + [f"checkpoint_path={ckpt_path}"]
+            ):
+                evaluate.run()
+
+        # Delete log folder
+        try:
+            shutil.rmtree("./logs", False, None)
+        except (OSError, WindowsError):
+            warnings.warn("Unable to delete folder {}.".format("./logs"))
+        return 0
+    except Exception as e:
+        print(e)
+        return 1
+
+
+def test_sheeprl_train_base(mocker):
+    assert (
+        func(
+            mocker,
+            2,
+            ["exp=custom_exp", "checkpoint.save_last=False"],
+        )
+        == 0
+    )
+
+
+def test_sheeprl_train_parallel_envs(mocker):
+    assert (
+        func(
+            mocker,
+            6,
+            ["exp=custom_parallel_env_exp", "checkpoint.save_last=False"],
+        )
+        == 0
+    )
+
+
+def test_sheeprl_train_fabric(mocker):
+    assert (
+        func(
+            mocker,
+            2,
+            [
+                "exp=custom_fabric_exp",
+                "fabric.accelerator=cpu",
+                "fabric.devices=1",
+                "checkpoint.save_last=False",
+            ],
+        )
+        == 0
+    )
+
+
+def test_sheeprl_train_metrics(mocker):
+    assert (
+        func(
+            mocker,
+            2,
+            [
+                "exp=custom_metric_exp",
+                "fabric.accelerator=cpu",
+                "fabric.devices=1",
+                "checkpoint.save_last=False",
+            ],
+        )
+        == 0
+    )
+
+
+def test_sheeprl_evaluation(mocker):
+    assert (
+        func(
+            mocker,
+            3,
+            [
+                "exp=custom_exp",
+                "checkpoint.save_last=True",
+                "root_dir=pytest_ppo",
+                "run_name=eval",
+            ],
+            evaluation=True,
+            root_dir="pytest_ppo",
+            run_name="eval",
+        )
+        == 0
+    )


### PR DESCRIPTION
Added some examples on how to use SheepRL to train an agent in Diambra environments:
- Added `sheeprl/logs` folder to the `.gitignore` file.
- Created folder `sheeprl`.
- Added `train.py` and `evaluate.py` scripts that take the configurations specified by the user and start training and evaluation, respectively.
- Added `.env` file to the `sheeprl` folder to define the `SHEEPRL_SEARCH_PATH` environment variable.
- Added `configs` folder with the configurations of the `agents`, `environments`, and `experiments`.